### PR TITLE
Us/14 merchant invoices index

### DIFF
--- a/app/controllers/merchants/invoices_controller.rb
+++ b/app/controllers/merchants/invoices_controller.rb
@@ -1,6 +1,6 @@
 class Merchants::InvoicesController < ApplicationController
   def index
-    
+    @merchant = Merchant.find(params[:merchant_id])
   end
 
   def show

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -49,4 +49,8 @@ class Merchant < ApplicationRecord
   def self.disabled
     where(enabled: :false)
   end
+
+  def uniq_invoices
+    invoices.distinct
+  end
 end

--- a/app/views/merchants/invoices/index.html.erb
+++ b/app/views/merchants/invoices/index.html.erb
@@ -1,0 +1,8 @@
+<%= render partial: '/merchants/header', locals: {merchant: @merchant.name} %>
+
+<h3><b>My Invoices</b></h3>
+<% @merchant.uniq_invoices.each do |invoice| %>
+<div id="invoice_<%= invoice.id %>">
+  <p>Invoice #<%= link_to invoice.id, merchant_invoice_path(@merchant, invoice) %></P>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,6 @@ Rails.application.routes.draw do
   
   resources :merchants, only: [] do
     resources :items, controller: 'merchants/items'
-  end
-
-  resources :merchants, only: [] do
     resources :invoices, only: [:index, :show], controller: 'merchants/invoices'
   end
 

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 RSpec.describe '/merchants/merchant_id/invoices', type: :feature do
   before(:each) do
-    test_data
     merchant2_test_data
   end
   describe "When I visit my merchant's invoices index page" do
     it "Then I see all of the invoices that include at least one of my merchant's items" do
-      
-    end
+      visit merchant_invoices_path(@merchant)
 
-    xit "For each invoice I see its id and each id links to the merchant invoice show page" do
+      expect(page).to have_content("Little Esty Shop")
+      expect(page).to have_content(@merchant.name)
+      expect(page).to have_content("My Invoices")
+      expect(page).to have_content("Invoice #{@invoice.id}")
+    end
   end
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe '/merchants/merchant_id/invoices', type: :feature do
   end
   describe "When I visit my merchant's invoices index page" do
     it "Then I see all of the invoices that include at least one of my merchant's items" do
-      visit merchant_invoices_path(@merchant)
+      visit merchant_invoices_path(@merchant2)
 
       expect(page).to have_content("Little Esty Shop")
-      expect(page).to have_content(@merchant.name)
+      expect(page).to have_content(@merchant2.name)
+      save_and_open_page
       expect(page).to have_content("My Invoices")
-      expect(page).to have_content("Invoice #{@invoice.id}")
+      expect(page).to have_content("Invoice ##{@invoice7.id}")
     end
+    #And each id links to the merchant invoice show page
   end
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -7,13 +7,35 @@ RSpec.describe '/merchants/merchant_id/invoices', type: :feature do
   describe "When I visit my merchant's invoices index page" do
     it "Then I see all of the invoices that include at least one of my merchant's items" do
       visit merchant_invoices_path(@merchant2)
-
+      
       expect(page).to have_content("Little Esty Shop")
       expect(page).to have_content(@merchant2.name)
-      save_and_open_page
       expect(page).to have_content("My Invoices")
       expect(page).to have_content("Invoice ##{@invoice7.id}")
+      expect(page).to have_content("Invoice ##{@invoice8.id}")
+      expect(page).to have_content("Invoice ##{@invoice9.id}")
+      expect(page).to have_content("Invoice ##{@invoice10.id}")
+      expect(page).to have_content("Invoice ##{@invoice11.id}")
+      expect(page).to have_content("Invoice ##{@invoice12.id}")
+      expect(page).to have_content("Invoice ##{@invoice13.id}")
     end
-    #And each id links to the merchant invoice show page
+    it 'each id links to the merchant invoice show page' do
+      visit merchant_invoices_path(@merchant2)
+      
+      click_link("#{@invoice7.id}")
+      expect(current_path).to eq(merchant_invoice_path(@merchant2, @invoice7))
+      
+      visit merchant_invoices_path(@merchant2)
+      click_link("#{@invoice8.id}")
+      expect(current_path).to eq(merchant_invoice_path(@merchant2, @invoice8))
+      
+      visit merchant_invoices_path(@merchant2)
+      click_link("#{@invoice9.id}")
+      expect(current_path).to eq(merchant_invoice_path(@merchant2, @invoice9))
+      
+      visit merchant_invoices_path(@merchant2)
+      click_link("#{@invoice10.id}")
+      expect(current_path).to eq(merchant_invoice_path(@merchant2, @invoice10))
+    end
   end
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe '/merchants/merchant_id/invoices', type: :feature do
+  before(:each) do
+    test_data
+    merchant2_test_data
+  end
+  describe "When I visit my merchant's invoices index page" do
+    it "Then I see all of the invoices that include at least one of my merchant's items" do
+      
+    end
+
+    xit "For each invoice I see its id and each id links to the merchant invoice show page" do
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Merchant, type: :model do
       expect(@merchant2.top_five_items[2].tot_revenue).to eq(10000)
       expect(@merchant2.top_five_items[3].tot_revenue).to eq(1000)
       expect(@merchant2.top_five_items[4].tot_revenue).to eq(100)
+    end
 
     it 'switches merchant.enabled' do
       expect(@merchant.enabled?)
@@ -70,7 +71,13 @@ RSpec.describe Merchant, type: :model do
       @merchant.switch_enabled
       expect(@merchant.enabled?)
     end
+
+    it '#uniq_invoices' do
+      expect(@merchant.uniq_invoices).to eq([@invoice1, @invoice2, @invoice3, @invoice4, @invoice5, @invoice6])
+      expect(@merchant2.uniq_invoices).to eq([@invoice7, @invoice8, @invoice9, @invoice10, @invoice11, @invoice12, @invoice13])
+    end
   end
+  
 
   describe 'model methods' do
     it '.enabled' do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe Merchant, type: :model do
     end
 
     it '#top_five_items, has attributes for tot_revenue invoice_items(unit_price * quantity)' do
-      expect(@merchant2.top_five_items.first.tot_revenue).to eq(10020625)
+      expect(@merchant2.top_five_items.first.tot_revenue).to eq(10043125)
       expect(@merchant2.top_five_items[1].tot_revenue).to eq(100000)
-      expect(@merchant2.top_five_items[2].tot_revenue).to eq(10000)
+      expect(@merchant2.top_five_items[2].tot_revenue).to eq(40000)
       expect(@merchant2.top_five_items[3].tot_revenue).to eq(1000)
       expect(@merchant2.top_five_items[4].tot_revenue).to eq(100)
     end


### PR DESCRIPTION
This PR contains the work for user story 14 as well as some minor refactors.
Model tests for top 5 total revenue were fixed with adding an `end` and updating some of the expected statements. There is still a failing test on this page though.

Merchant invoice controller was updated with an index action
Merchant invoice index view all set up with invoice ids as links that lead to their individual show pages.