### PR TITLE
Us15/real merchant invoice show page

### DIFF
--- a/app/controllers/merchants/invoices_controller.rb
+++ b/app/controllers/merchants/invoices_controller.rb
@@ -4,6 +4,7 @@ class Merchants::InvoicesController < ApplicationController
   end
 
   def show
-    
+    @merchant = Merchant.find(params[:merchant_id])
+    @invoice = Invoice.find(params[:id])
   end
 end

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: '/merchants/header', locals: {merchant: @merchant.name} %>
+
+<h3><b>Invoice #<%= @invoice.id %></b></h3>
+
+<p>Status: <%= @invoice.status %></p>
+<p>Created on: <%= @invoice.created_at.strftime("%B/%d/%Y") %>
+
+<h4>Customer:</h4>
+<p><%= @invoice.customer.full_name %></p>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
   before(:each) do
+    test_data
     merchant2_test_data
   end
   describe "When I visit my merchant's invoice show page" do
@@ -15,6 +16,16 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       expect(page).to have_content("Created on: #{@invoice7.created_at.strftime("%B/%d/%Y")}")
       expect(page).to have_content("Customer:")
       expect(page).to have_content("#{@customer7.full_name}")
+
+      visit merchant_invoice_path(@merchant, @invoice1)
+
+      expect(page).to have_content("Little Esty Shop")
+      expect(page).to have_content(@merchant.name)
+      expect(page).to have_content(@invoice1.id)
+      expect(page).to have_content(@invoice1.status)
+      expect(page).to have_content("Created on: #{@invoice1.created_at.strftime("%B/%d/%Y")}")
+      expect(page).to have_content("Customer:")
+      expect(page).to have_content("#{@customer1.full_name}")
     end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
     merchant2_test_data
   end
   describe "When I visit my merchant's invoice show page" do
-    it 'I see information related to that invoice including: id, status, created at, customer name'
-      visit merchant_invoice_path(@merchant2)
+    it 'I see information related to that invoice including: id, status, created at, customer name' do
+      visit merchant_invoice_path(@merchant2, @invoice7)
 
       expect(page).to have_content("Little Esty Shop")
       expect(page).to have_content(@merchant2.name)
@@ -15,5 +15,6 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       expect(page).to have_content("Created on: #{@invoice7.created_at.strftime("%B/%d/%Y")}")
       expect(page).to have_content("Customer:")
       expect(page).to have_content("#{customer7.full_name}")
+    end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       expect(page).to have_content(@invoice7.status)
       expect(page).to have_content("Created on: #{@invoice7.created_at.strftime("%B/%d/%Y")}")
       expect(page).to have_content("Customer:")
-      expect(page).to have_content("#{customer7.full_name}")
+      expect(page).to have_content("#{@customer7.full_name}")
     end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
+  before(:each) do
+    merchant2_test_data
+  end
+  describe "When I visit my merchant's invoice show page" do
+    it 'I see information related to that invoice including: id, status, created at, customer name'
+      visit merchant_invoice_path(@merchant2)
+
+      expect(page).to have_content("Little Esty Shop")
+      expect(page).to have_content(@merchant2.name)
+      expect(page).to have_content(@invoice7.id)
+      expect(page).to have_content(@invoice7.status)
+      expect(page).to have_content("Created on: #{@invoice7.created_at.strftime("%B/%d/%Y")}")
+      expect(page).to have_content("Customer:")
+      expect(page).to have_content("#{customer7.full_name}")
+  end
+end


### PR DESCRIPTION
This PR contains all the work for user story 15. The merchant items show page.
Tests cover both sets of test data.
Reused the `full_name` method (Thank you to whoever made that!).
Merchant and Invoice params added to show action in merchant item controller.
Beginning stages of merchant item show page complete. Further user stories will develop it more.
