### PR TITLE
Us16 17 merchant invoice show

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -53,4 +53,11 @@ class Merchant < ApplicationRecord
   def uniq_invoices
     invoices.distinct
   end
+
+  def invoice_items_data(invoice_id)
+    items.joins(:invoices)
+    .select("items.*, invoice_items.quantity, invoice_items.unit_price as sold_price, invoice_items.status as invitm_status")
+    .where(invoices: {id: invoice_id})
+    .distinct
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -62,9 +62,7 @@ class Merchant < ApplicationRecord
   end
 
   def inv_total_rev(invoice_id)
-require 'pry'; binding.pry
-    invoice_items.select("sum(invoice_items.quantity * invoice_items.unit_price)").where(invoice_items: {invoice_id: invoice_id}).group(:invoice_id)
+    invoice_items.where(invoice_items: {invoice_id: invoice_id})
+    .sum("invoice_items.quantity * invoice_items.unit_price")
   end
-
-  
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -60,4 +60,11 @@ class Merchant < ApplicationRecord
     .where(invoices: {id: invoice_id})
     .distinct
   end
+
+  def inv_total_rev(invoice_id)
+require 'pry'; binding.pry
+    invoice_items.select("sum(invoice_items.quantity * invoice_items.unit_price)").where(invoice_items: {invoice_id: invoice_id}).group(:invoice_id)
+  end
+
+  
 end

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -7,3 +7,23 @@
 
 <h4>Customer:</h4>
 <p><%= @invoice.customer.full_name %></p>
+
+<h4>Items on this Invoice:</h4>
+
+<table>
+  <tr>
+    <th>Item Name</th>
+    <th>Quantity</th>
+    <th>Unit Price</th>
+    <th>Status</th>
+  </tr>
+  <% @merchant.invoice_items_data(@invoice.id).each do |item| %>
+    <tr>
+      <td><%= item.name %></td>
+      <td><%= item.quantity %></td>
+      <td><%= item.sold_price %></td>
+      <td><%= item.invitm_status %></td>
+    </tr>
+  <% end %>
+</table>
+  

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -23,7 +23,7 @@ tr:nth-child(even) {
 <p>Status: <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.created_at.strftime("%B/%d/%Y") %>
 
-<p>Total Revenue:<%= number_to_currency(@merchant.inv_total_rev(@invoice.id)) %><p>
+<p>Total Revenue: <%= number_to_currency(@merchant.inv_total_rev(@invoice.id)/100) %><p>
 
 <h4>Customer:</h4>
 <p><%= @invoice.customer.full_name %></p>

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -23,6 +23,8 @@ tr:nth-child(even) {
 <p>Status: <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.created_at.strftime("%B/%d/%Y") %>
 
+<p>Total Revenue:<%= number_to_currency(@merchant.inv_total_rev(@invoice.id)) %><p>
+
 <h4>Customer:</h4>
 <p><%= @invoice.customer.full_name %></p>
 

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -1,3 +1,21 @@
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #dddddd;
+}
+</style>
+
 <%= render partial: '/merchants/header', locals: {merchant: @merchant.name} %>
 
 <h3><b>Invoice #<%= @invoice.id %></b></h3>
@@ -18,11 +36,19 @@
     <th>Status</th>
   </tr>
   <% @merchant.invoice_items_data(@invoice.id).each do |item| %>
-    <tr>
+    <tr id="item_<%= item.id %>" >
       <td><%= item.name %></td>
       <td><%= item.quantity %></td>
       <td><%= item.sold_price %></td>
-      <td><%= item.invitm_status %></td>
+      <td>
+      <% if item.invitm_status == 0 %>
+        <%= "pending" %>
+      <% elsif item.invitm_status == 1 %>
+        <%= "packaged" %>
+      <% else %>
+        <%= "shipped" %>
+      <% end %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -45,9 +45,12 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       end
       expect(page).to_not have_content(@item12.name) 
     end
-
+    
     it 'I see the total revenue that will be generated from all of my items on the invoice' do
+      merchant3_test_data
+      visit merchant_invoice_path(@merchant2, @invoice7)
       
+      expect(page).to have_content("Total Revenue: $175.00")
     end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -45,5 +45,9 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       end
       expect(page).to_not have_content(@item12.name) 
     end
+
+    it 'I see the total revenue that will be generated from all of my items on the invoice' do
+      
+    end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
-  before(:each) do
-    test_data
-    merchant2_test_data
-  end
   describe "When I visit my merchant's invoice show page" do
     it 'I see information related to that invoice including: id, status, created at, customer name' do
+      test_data
+      merchant2_test_data
       visit merchant_invoice_path(@merchant2, @invoice7)
 
       expect(page).to have_content("Little Esty Shop")
@@ -26,6 +24,25 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
       expect(page).to have_content("Created on: #{@invoice1.created_at.strftime("%B/%d/%Y")}")
       expect(page).to have_content("Customer:")
       expect(page).to have_content("#{@customer1.full_name}")
+    end
+
+    it 'I see all of my items on the invoice (name, quantity ordered, price the item sold for and invoice item status)' do
+      merchant3_test_data
+      visit merchant_invoice_path(@merchant2, @invoice7)
+
+      expect(page).to have_content("Items on this Invoice:")
+      within "#item_#{@item6.id}" do
+        expect(page).to have_content(@item6.name)
+        expect(page).to have_content(@init1.quantity)
+        expect(page).to have_content(@init1.unit_price)
+        expect(page).to have_content(@init1.status)
+      end
+      within "#item_#{@item11.id}" do
+        expect(page).to have_content(@item11.name)
+        expect(page).to have_content(@init8.quantity)
+        expect(page).to have_content(@init8.unit_price)
+        expect(page).to have_content(@init8.status)
+      end
     end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe '/merchants/merchant_id/invoices/invoice_id)', type: :feature do
         expect(page).to have_content(@init8.unit_price)
         expect(page).to have_content(@init8.status)
       end
+      expect(page).to_not have_content(@item12.name) 
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Merchant, type: :model do
       expect(@merchant3.invoice_items_data(@invoice7.id)).to eq([@item12])
       expect(@merchant4.invoice_items_data(@invoice7.id)).to eq([])
     end
+
     it '#inv_total_rev can find the total revenue from an invoice for a specific merchant' do
-      expect(@merchant2.inv_total_rev(@invoice7.id)).to eq("17500")
+      expect(@merchant2.inv_total_rev(@invoice7.id)).to eq(17500)
     end
 
     before(:each) do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,16 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Merchant, type: :model do
-  before(:each) do
-    test_data
-    merchant2_test_data
-  end
   it { should have_many(:items) }
   it { should have_many(:invoice_items).through(:items)}
   it { should have_many(:invoices).through(:items)}
   it { should have_many(:customers).through(:invoices)}
-
+  
   describe 'instance methods' do
+    it '#invoice_items_data, to return a list of items for a specific merchant on a specific invoice' do
+      merchant3_test_data
+
+      expect(@merchant2.invoice_items_data(@invoice7.id)).to eq([@item6, @item11])
+      expect(@merchant3.invoice_items_data(@invoice7.id)).to eq([@item12])
+      expect(@merchant4.invoice_items_data(@invoice7.id)).to eq([])
+    end
+
+    before(:each) do
+      test_data
+      merchant2_test_data
+    end
     it '#top_5_customers' do
       expect(@merchant.top_5_customers).to match_array([@customer6, @customer2, @customer3, @customer4, @customer5])
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Merchant, type: :model do
       expect(@merchant3.invoice_items_data(@invoice7.id)).to eq([@item12])
       expect(@merchant4.invoice_items_data(@invoice7.id)).to eq([])
     end
+    it '#inv_total_rev can find the total revenue from an invoice for a specific merchant' do
+      expect(@merchant2.inv_total_rev(@invoice7.id)).to eq("17500")
+    end
 
     before(:each) do
       test_data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,6 +94,59 @@ def merchant2_test_data
   @init8 = create(:invoice_item, item: @item11, invoice: @invoice7, unit_price: 500, quantity: 15)
   @init9 = create(:invoice_item, item: @item11, invoice: @invoice9, unit_price: 525, quantity: 25)
 end
+
+def merchant3_test_data
+  @merchant2 = create(:merchant)
+  @merchant3 = create(:merchant)
+  @merchant4 = create(:merchant)
+
+  @item6 = create(:item, merchant: @merchant2)
+  @item7 = create(:item, merchant: @merchant2)
+  @item8 = create(:item, merchant: @merchant2)
+  @item9 = create(:item, merchant: @merchant2)
+  @item10 = create(:item, merchant: @merchant2)
+  @item11 = create(:item, merchant: @merchant2)
+  @item12 = create(:item, merchant: @merchant3)
+
+  @customer7 = create(:customer)
+  @customer8 = create(:customer)
+  @customer9 = create(:customer)
+  @customer10 = create(:customer)
+  @customer11 = create(:customer)
+  @customer12 = create(:customer)
+
+  @invoice7 = create(:invoice, customer: @customer7)
+  @invoice8 = create(:invoice, customer: @customer8)
+  @invoice9 = create(:invoice, customer: @customer9)
+  @invoice10 = create(:invoice, customer: @customer10)
+  @invoice11 = create(:invoice, customer: @customer11)
+  @invoice12 = create(:invoice, customer: @customer12)
+  @invoice13 = create(:invoice, customer: @customer12)
+
+  @tran1 = create(:transaction, result: 'success', invoice: @invoice7)
+  @tran2 = create(:transaction, result: 'failed', invoice: @invoice7)
+  @tran3 = create(:transaction, result: 'failed', invoice: @invoice8)
+  @tran4 = create(:transaction, result: 'failed', invoice: @invoice8)
+  @tran5 = create(:transaction, result: 'success', invoice: @invoice9)
+  @tran6 = create(:transaction, result: 'success', invoice: @invoice10)
+  @tran7 = create(:transaction, result: 'success', invoice: @invoice11)
+  @tran8 = create(:transaction, result: 'success', invoice: @invoice12)
+  @tran9 = create(:transaction, result: 'success', invoice: @invoice13)
+  @tran10 = create(:transaction, result: 'success', invoice: @invoice7)
+  @tran11 = create(:transaction, result: 'success', invoice: @invoice7)
+  @tran13 = create(:transaction, result: 'success', invoice: @invoice7)
+  
+  @init1 = create(:invoice_item, item: @item6, invoice: @invoice7, unit_price: 1000, quantity: 10)
+  @init2 = create(:invoice_item, item: @item7, invoice: @invoice8, unit_price: 10000, quantity: 1000)
+  @init3 = create(:invoice_item, item: @item8, invoice: @invoice9, unit_price: 1000, quantity: 100)
+  @init4 = create(:invoice_item, item: @item9, invoice: @invoice10, unit_price: 100, quantity: 10)
+  @init5 = create(:invoice_item, item: @item10, invoice: @invoice11, unit_price: 1, quantity: 10)
+  @init7 = create(:invoice_item, item: @item12, invoice: @invoice13, unit_price: 10, quantity: 10)
+  @init6 = create(:invoice_item, item: @item11, invoice: @invoice12, unit_price: 1000000, quantity: 10)
+  @init8 = create(:invoice_item, item: @item11, invoice: @invoice7, unit_price: 500, quantity: 15)
+  @init9 = create(:invoice_item, item: @item11, invoice: @invoice9, unit_price: 525, quantity: 25)
+  @init10 = create(:invoice_item, item: @item12, invoice: @invoice7, unit_price: 525, quantity: 25)
+end
 # item11, item8, item6, item9, item12
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'


### PR DESCRIPTION
This PR contains the work for user stories 16 and 17.
Displaying items for a specific merchant's invoice
Displaying the total revenue for a specific merchant's invoice
Added two query methods to the merchant model. One for invoice items data, and one for invoice total revenue
All required model tests and feature tests